### PR TITLE
Add additional step to unlock accelerator dropdown

### DIFF
--- a/website/slides/slides-04-deep-learning-exercise.qmd
+++ b/website/slides/slides-04-deep-learning-exercise.qmd
@@ -28,7 +28,6 @@ Follow the guidelines in the next page.
 
 4. Select `+ New Notebook`
 <img src="img/create_notebook.png" alt="drawing" width="400"/>
-
 5. Click `File` on the top left side of your Kaggle notebook, select `Import Notebook`
 <img src="img/import_notebook.png" alt="drawing" width="400"/>
 
@@ -39,6 +38,8 @@ Follow the guidelines in the next page.
 7. On the right-hand side of your Kaggle notebook, find `Session options` and make sure:
 
   - `INTERNET` is enabled.
+
+  - You have clicked on the 'Get phone verified' text at the bottom of the options menu to enable the `ACCELERATOR` dropdown.
 
   - In the `ACCELERATOR` dropdown, choose the options starts with `GPU` when you're ready to use it (you can turn it on/off as you need it).
   


### PR DESCRIPTION
This change adds an additional step to step 6 of the setup documentation.
The Accelerator dropdown does not show up unless students click on the "Get phone verified" text located at the bottom of session options.
https://github.com/user-attachments/assets/f97aa166-301f-49e7-831c-0c64bc8c8033



Hence, the modified slide looks like:
<img width="676" alt="Screenshot 2025-03-08 at 7 06 20 PM" src="https://github.com/user-attachments/assets/3b9825d7-e578-4521-be97-9431bb13e35b" />